### PR TITLE
Support mender-partuuid feature

### DIFF
--- a/classes/mender-kernel-helpers.bbclass
+++ b/classes/mender-kernel-helpers.bbclass
@@ -4,8 +4,13 @@ mender_kernel_delete_kernel_parts() {
     bbfatal "mender_kernel_delete_kernel_parts()::file($1) is not valid or does not exist"
   fi
 
-  local kernelparta="${MENDER/KERNEL_PART_A}"
-  local kernelpartb="${MENDER/KERNEL_PART_B}"
+  if ${@bb.utils.contains('MENDER_FEATURES', 'mender-partuuid', 'true', 'false', d)}; then
+    local kernelparta="PARTUUID=${@os.path.basename(d.getVar('MENDER/KERNEL_PART_A'))}"
+    local kernelpartb="PARTUUID=${@os.path.basename(d.getVar('MENDER/KERNEL_PART_B'))}"
+  else
+    local kernelparta="${MENDER/KERNEL_PART_A}"
+    local kernelpartb="${MENDER/KERNEL_PART_B}"
+  fi
 
   sed -i -e "\|${kernelparta}|d" \
          -e "\|${kernelpartb}|d" \

--- a/classes/mender-kernel-setup.bbclass
+++ b/classes/mender-kernel-setup.bbclass
@@ -24,10 +24,6 @@ python do_mender_kernel_checks() {
     #TODO : probably would require mender/uboot patches
     bb.fatal("mender-kernel does not currently support mender-uboot")
 
-  elif bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-partuuid'   , True, False, d):
-    #TODO : just haven't looked into it at all
-    bb.fatal("mender-kernel does not currently support mender-partuuid")
-
   ##############################################################################
   elif int(d.expand('${MENDER_BOOT_PART_SIZE_MB}', 0)) <= 0:
     bb.fatal("mender-kernel requires MENDER_BOOT_PART_SIZE_MB > 0")

--- a/classes/mender-kernel-vars.bbclass
+++ b/classes/mender-kernel-vars.bbclass
@@ -8,9 +8,10 @@ MENDER_EXTRA_PARTS[kernelb]                = "--label=${MENDER/KERNEL_PART_B_NAM
 MENDER_EXTRA_PARTS_SIZES_MB[kernela]       = "${MENDER/KERNEL_PART_SIZE_MB}"
 MENDER_EXTRA_PARTS_SIZES_MB[kernelb]       = "${MENDER/KERNEL_PART_SIZE_MB}"
 
-MENDER/KERNEL_PART_A                       = "${MENDER_STORAGE_DEVICE_BASE}${MENDER/KERNEL_PART_A_NUMBER}"
+
+MENDER/KERNEL_PART_A                       = "${@bb.utils.contains('MENDER_FEATURES', 'mender-partuuid', "/dev/disk/by-partuuid/" + (d.getVarFlags('MENDER_EXTRA_PARTS_UUID') or dict()).get('kernela', ''), d.getVar('MENDER_STORAGE_DEVICE_BASE') + d.getVar('MENDER/KERNEL_PART_A_NUMBER'), d)}"
 MENDER/KERNEL_PART_A_NUMBER                = "${@mender_get_extra_parts_offset_by_id(d, "${MENDER/KERNEL_PART_A_NAME}")}"
-MENDER/KERNEL_PART_B                       = "${MENDER_STORAGE_DEVICE_BASE}${MENDER/KERNEL_PART_B_NUMBER}"
+MENDER/KERNEL_PART_B                       = "${@bb.utils.contains('MENDER_FEATURES', 'mender-partuuid', "/dev/disk/by-partuuid/" + (d.getVarFlags('MENDER_EXTRA_PARTS_UUID') or dict()).get('kernelb', ''), d.getVar('MENDER_STORAGE_DEVICE_BASE') + d.getVar('MENDER/KERNEL_PART_B_NUMBER'), d)}"
 MENDER/KERNEL_PART_B_NUMBER                = "${@mender_get_extra_parts_offset_by_id(d, "${MENDER/KERNEL_PART_B_NAME}")}"
 
 MENDER/KERNEL_PART_FSOPTS                ??= "${MENDER/KERNEL_PART_FSOPTS_DEFAULT}"

--- a/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_%.bbappend
+++ b/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_%.bbappend
@@ -3,8 +3,16 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'file://90_mender_boot_grub.patch', '', d)}"
 
 do_configure:append() {
-  echo "mender_kernela_part=$(get_part_number_from_device ${MENDER/KERNEL_PART_A})" >> ${B}/mender_grubenv_defines
-  echo "mender_kernelb_part=$(get_part_number_from_device ${MENDER/KERNEL_PART_B})" >> ${B}/mender_grubenv_defines
+  if ${@bb.utils.contains('MENDER_FEATURES', 'mender-partuuid', 'true', 'false', d)}; then
+    echo "mender_kernela_part=${MENDER/KERNEL_PART_A_NUMBER}" >> ${B}/mender_grubenv_defines
+    echo "mender_kernelb_part=${MENDER/KERNEL_PART_B_NUMBER}" >> ${B}/mender_grubenv_defines
+    echo "mender_kernela_uuid=${@mender_get_partuuid_from_device(d, '${MENDER/KERNEL_PART_A}')}" >> ${B}/mender_grubenv_defines
+    echo "mender_kernelb_uuid=${@mender_get_partuuid_from_device(d, '${MENDER/KERNEL_PART_B}')}" >> ${B}/mender_grubenv_defines
+  else
+    echo "mender_kernela_part=$(get_part_number_from_device ${MENDER/KERNEL_PART_A})" >> ${B}/mender_grubenv_defines
+    echo "mender_kernelb_part=$(get_part_number_from_device ${MENDER/KERNEL_PART_B})" >> ${B}/mender_grubenv_defines
+  fi
+
   echo "initrd_imagetype=${MENDER/KERNEL_INITRAMFS_LINK_NAME}"                      >> ${B}/mender_grubenv_defines
 }
 

--- a/recipes-mender/mender-kernel-state-scripts/files/write-kernel-part.sh
+++ b/recipes-mender/mender-kernel-state-scripts/files/write-kernel-part.sh
@@ -38,46 +38,46 @@ ROOT_MNT_DIR="@@MENDER/KERNEL_ROOT_CANDIDATE_MNT_DIR@@"
 if   [ "$BOOT_PART" -eq "@@MENDER_ROOTFS_PART_A_NUMBER@@" ] && [ "$UPGRADE_AV" -ne "0" ]; then
   # an update has already happened, but the system hasn't restarted. mender is now overwriting it.
   # don't need to invert the reported mender_boot_part
-  ROOT_PART="@@MENDER_ROOTFS_PART_A_NUMBER@@"
-  KERN_PART="@@MENDER/KERNEL_PART_A_NUMBER@@"
+  ROOT_PART="@@MENDER_ROOTFS_PART_A@@"
+  KERN_PART="@@MENDER/KERNEL_PART_A@@"
 
 elif [ "$BOOT_PART" -eq "@@MENDER_ROOTFS_PART_A_NUMBER@@" ]; then
   # invert mender_boot_part to mount the update candidate partitions
-  ROOT_PART="@@MENDER_ROOTFS_PART_B_NUMBER@@"
-  KERN_PART="@@MENDER/KERNEL_PART_B_NUMBER@@"
+  ROOT_PART="@@MENDER_ROOTFS_PART_B@@"
+  KERN_PART="@@MENDER/KERNEL_PART_B@@"
 
 elif [ "$BOOT_PART" -eq "@@MENDER_ROOTFS_PART_B_NUMBER@@" ] && [ "$UPGRADE_AV" -ne "0" ]; then
   # an update has already happened, but the system hasn't restarted. mender is now overwriting it.
   # don't need to invert the reported mender_boot_part
-  ROOT_PART="@@MENDER_ROOTFS_PART_B_NUMBER@@"
-  KERN_PART="@@MENDER/KERNEL_PART_B_NUMBER@@"
+  ROOT_PART="@@MENDER_ROOTFS_PART_B@@"
+  KERN_PART="@@MENDER/KERNEL_PART_B@@"
 
 elif [ "$BOOT_PART" -eq "@@MENDER_ROOTFS_PART_B_NUMBER@@" ]; then
   # invert mender_boot_part to mount the update candidate partitions
-  ROOT_PART="@@MENDER_ROOTFS_PART_A_NUMBER@@"
-  KERN_PART="@@MENDER/KERNEL_PART_A_NUMBER@@"
+  ROOT_PART="@@MENDER_ROOTFS_PART_A@@"
+  KERN_PART="@@MENDER/KERNEL_PART_A@@"
 
 else
-  fatal "@@MENDER_STORAGE_DEVICE_BASE@@$BOOT_PART is not a known rootfs partition"
+  fatal "invalid or unknown rootfs partition: $BOOT_PART"
 
 fi
 
-log "updating @@MENDER_STORAGE_DEVICE_BASE@@$KERN_PART with new kernel candidate from @@MENDER_STORAGE_DEVICE_BASE@@$ROOT_PART"
+log "updating $KERN_PART with new kernel candidate from $ROOT_PART"
 
 if ! mount |                                      grep -q $ROOT_MNT_DIR; then
   mkdir -p                                                $ROOT_MNT_DIR
-  mount -o ro  @@MENDER_STORAGE_DEVICE_BASE@@$ROOT_PART   $ROOT_MNT_DIR
-  log "mounted @@MENDER_STORAGE_DEVICE_BASE@@$ROOT_PART @ $ROOT_MNT_DIR"
+  mount -o ro  $ROOT_PART   $ROOT_MNT_DIR
+  log "mounted $ROOT_PART @ $ROOT_MNT_DIR"
 fi
 
 if ! mount |                                      grep -q $KERN_MNT_DIR; then
   mkdir -p                                                $KERN_MNT_DIR
-  mount -o rw  @@MENDER_STORAGE_DEVICE_BASE@@$KERN_PART   $KERN_MNT_DIR
-  log "mounted @@MENDER_STORAGE_DEVICE_BASE@@$KERN_PART @ $KERN_MNT_DIR"
+  mount -o rw  $KERN_PART   $KERN_MNT_DIR
+  log "mounted $KERN_PART @ $KERN_MNT_DIR"
 fi
 
 rsync -avqI $ROOT_MNT_DIR/$KERN_SRC_DIR/*                 $KERN_MNT_DIR --exclude $(basename @@MENDER_BOOT_PART_MOUNT_LOCATION@@)
 
-log "finished updating kernel partition: @@MENDER_STORAGE_DEVICE_BASE@@$KERN_PART"
+log "finished updating kernel partition: $KERN_PART"
 
 exit


### PR DESCRIPTION
I added support for mender-partuuid feature.

For example to configure the uuids in the machine.conf (if mender-partuuid feature is enabled):
```
MENDER_STORAGE_DEVICE = ""

MENDER_BOOT_PART = "/dev/disk/by-partuuid/c4995988-1872-43de-b00f-93b1ae305dde"
MENDER_ROOTFS_PART_A = "/dev/disk/by-partuuid/ba50cc80-d3d8-4b2b-b037-f8b257850f27"
MENDER_ROOTFS_PART_B = "/dev/disk/by-partuuid/0e45c799-fa31-4725-9b8b-e76eb4d29622"
MENDER_DATA_PART = "/dev/disk/by-partuuid/8318b861-bd80-4283-a797-2c3e7534a7ac"
MENDER_EXTRA_PARTS_UUID[kernela] = "99e2ffb2-ed9c-4d96-9836-236bbfe55b64"
MENDER_EXTRA_PARTS_UUID[kernelb] = "6e3b180c-ec41-442a-a6a7-ebf4c1bd8105"
```
Edit: signed off commit